### PR TITLE
improved version of the `road_density` function

### DIFF
--- a/R/assing_aadt.R
+++ b/R/assing_aadt.R
@@ -166,7 +166,7 @@ assign_aadt_major = function(lines, junctions, traffic, bounds,
                        major_ref = c("motorway","motorway_link","primary",
                                       "primary_link","trunk","trunk_link")){
 
-  # Transform to Britsh National Grid
+  # Transform to British National Grid
   lines = sf::st_transform(lines, 27700)
   junctions = sf::st_transform(junctions, 27700)
   traffic = sf::st_transform(traffic, 27700)
@@ -381,8 +381,3 @@ minor_roads_distance = function(lines, junc_majmi){
 
 
 }
-
-
-
-
-


### PR DESCRIPTION
I improved the calculation by using the `st_intersects` for all zones and lines, instead of doing it zone by zone, and also by using `vapply` instead of `lapply`.

Here is a benchmark of the functions with the Hull data, the values of density are identical.

```
alt_1 <- function(){
                        
int_func <- function(zone, lines){
  zone <- sf::st_sfc(zone, crs = 4326)
  line <-  lines[zone,]
  if(nrow(line) > 0){
    line <- sf::st_intersection(zone, line)
    road_length <- sum(as.numeric(sf::st_length(line))) / 1000
  } else {
    road_length <- 0
  }
  
  #qtm(zone) + qtm(line, lines.col = "blue")
  lsoa_area <- as.numeric(sf::st_area(zone)) / 1e6
  
  data.frame(road_km = road_length,
             area_km2 = lsoa_area,
             road_density = road_length / lsoa_area)
}

density <- pbapply::pblapply(sf::st_geometry(zones), int_func, lines = lines)
density <- dplyr::bind_rows(density)
zones1 <- cbind(zones, density)
return(zones1$road_density)
}

alt_2 <- function(){
  int_func2 <- function(zone){
    t_zone <- zones[zone,]
    line <- lines[zone_inter[[zone]],]
    
    if(nrow(line) == 0){
      return(0)
    } 
    
    line <- sf::st_intersection(t_zone, line)
    return(sum(as.numeric(sf::st_length(line))) / 1000)
  }
  
  zone_inter <- sf::st_intersects(zones,lines)
  
  road_km <- pbapply::pbvapply(seq_along(zone_inter),
                               int_func2,
                               FUN.VALUE = numeric(1))
  
  zones$road_km <- road_km
  
  zones1 <- zones |> mutate(area_km2 = as.numeric(st_area(geometry))/1e6,
                           density = road_km/area_km2)
  
  return(zones1$density)
  
}

mbench = microbenchmark::microbenchmark(alt_1(),alt_2(),times = 4,check = 'identical')
mbench

Unit: seconds
    expr      min       lq     mean   median       uq      max neval cld
 alt_1() 41.57146 41.84984 42.71117 42.18302 43.57249 44.90716     4  a 
 alt_2() 25.63950 25.66440 26.28379 26.21275 26.90317 27.07015     4   b



```